### PR TITLE
Fix script injection security issues in workflows

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,11 +45,13 @@ jobs:
 
       - id: deploy
         name: Deploy to Vercel
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           vercel deploy --no-wait \
             --token ${{ secrets.VERCEL_TOKEN }} \
-            --build-env MDX_CHANGELOG_BRANCH='${{ github.head_ref || github.ref_name }}' \
-            --env MDX_CHANGELOG_BRANCH='${{ github.head_ref || github.ref_name }}' \
+            --build-env MDX_CHANGELOG_BRANCH="$HEAD_REF" \
+            --env MDX_CHANGELOG_BRANCH="$HEAD_REF" \
             --build-env XATA_PREVIEW=none \
             --env XATA_PREVIEW=none \
             --build-env XATA_BRANCH=main \


### PR DESCRIPTION
## Summary
Move untrusted GitHub context values out of inline shell scripts into environment variables to prevent script injection attacks.

## Security concern
Directly interpolating `${{ github.head_ref }}` or `${{ github.event.pull_request.head.ref }}` into `run:` scripts allows an attacker to inject arbitrary shell commands by naming a branch with a payload like `x"; malicious command; echo "`.

## Fix
Each untrusted value is assigned to an environment variable in the step's `env:` block and referenced as `$VAR_NAME` in the script body.

See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions